### PR TITLE
Simple spell check fix on NC-get-conf readme

### DIFF
--- a/NC-get-config/README.md
+++ b/NC-get-config/README.md
@@ -1,8 +1,8 @@
 # NETCONF get-config
 
-This is an example Python script that literally just grabs the entiere config of a network element.
+This is an example Python script that literally just grabs the entire config of a network element.
 
-It's not just what you would see from the CLI exec command "show running-config". 
+It's not just what you would see from the CLI exec command "show running-config".
 You'll get everything. From all known open-models, and the native-model (which is the translation of the running config a human is used to).
 
 # requirements


### PR DESCRIPTION
I don't know if it is petty but I noticed it and I'm a Cisco/Python guy.